### PR TITLE
Provide custom way of rendering progress bar + typing fixes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ type Mode = 'hibernate' | 'init' | 'active' | 'complete' | 'inactive';
 
 interface Props {
   style?: Record<string, any>;
+  render?: (mode: Mode) => JSX.Element;
 }
 
 interface State {
@@ -124,6 +125,14 @@ export class ProgressBar extends Component<Props, State> {
 
     if (mode === 'hibernate') {
       return null;
+    }
+    
+    if(this.props.render) {
+      if(this.props.style) {
+        throw new Error('Can\'t set style and custom render function at the same time.');
+      }
+      
+      return this.props.render(mode);
     }
 
     const width = mode === 'complete' ? 100 : mode === 'init' ? 0 : 80;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -126,12 +126,12 @@ export class ProgressBar extends Component<Props, State> {
     if (mode === 'hibernate') {
       return null;
     }
-    
-    if(this.props.render) {
-      if(this.props.style) {
+
+    if (this.props.render) {
+      if (this.props.style) {
         throw new Error("Can't set style and custom render function at the same time.");
       }
-      
+
       return this.props.render(mode);
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -129,7 +129,7 @@ export class ProgressBar extends Component<Props, State> {
     
     if(this.props.render) {
       if(this.props.style) {
-        throw new Error('Can\'t set style and custom render function at the same time.');
+        throw new Error("Can't set style and custom render function at the same time.");
       }
       
       return this.props.render(mode);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -175,7 +175,7 @@ export function setOriginalFetch(nextOriginalFetch: FetchSignature): void {
  * @param {RequestOptions} [options] The options you want to pass for that request
  * @returns {Promise<Response>} A Promise which returns a Response
  */
-export async function progressBarFetch(url: string, options?: object): Promise<Response> {
+export async function progressBarFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
   activeRequests += 1;
 
   if (progressBar) {
@@ -183,7 +183,7 @@ export async function progressBarFetch(url: string, options?: object): Promise<R
   }
 
   try {
-    const response = await originalFetch(url, options);
+    const response = await originalFetch(input, init);
     activeRequests -= 1;
     return response;
   } catch (error) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -154,7 +154,7 @@ export class ProgressBar extends Component<Props, State> {
   }
 }
 
-type FetchSignature = (url: string, options?: object) => Promise<Response>;
+type FetchSignature = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 
 // We store the fetch here as provided by the user.
 let originalFetch: FetchSignature;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,7 @@ export let progressBar: ProgressBar;
 type Mode = 'hibernate' | 'init' | 'active' | 'complete' | 'inactive';
 
 interface Props {
-  style?: Record<string, any>;
+  style?: React.CSSProperties;
   render?: (mode: Mode) => JSX.Element;
 }
 


### PR DESCRIPTION
This will make it possible to use my own progress bar if needed.

Also fixed typings of `style` prop (which in turn removed linter warning), and also improved the type of `fetch` to be more precise.